### PR TITLE
fix: height of description background for activities

### DIFF
--- a/src/components/EventCard/event-card.scss
+++ b/src/components/EventCard/event-card.scss
@@ -26,8 +26,9 @@
   z-index: 10;
   top:0;
 
-  background: linear-gradient(to bottom, rgba(0,8,99,0.8) 30%, rgba(255,255,255,0.1) 100%);
-  // background-color: rgba(0,8,99,0.7);
+  //background: linear-gradient(to bottom, rgba(0,8,99,0.8) 30%, rgba(255,255,255,0.1) 100%);
+  background-color: rgba(0,8,99,0.7);
+
   // @media (max-width: $lg) {
   //   margin-bottom: 30px;
   // }

--- a/src/pages/Activities/activities.scss
+++ b/src/pages/Activities/activities.scss
@@ -4,3 +4,8 @@
 .event-card-wrapper {
   position: relative;
 }
+
+
+.event-card__fullDescription {
+  margin-bottom: 0px !important;
+}


### PR DESCRIPTION
### Descrição

Na pagina das Atividades, o backround da full description nao estava enquadrado com o card

<img width="385" alt="image" src="https://user-images.githubusercontent.com/6379428/230791609-a0fa1efb-6e5d-4e94-8fef-3067e2d4abee.png">

<img width="359" alt="image" src="https://user-images.githubusercontent.com/6379428/230791902-dd89f08f-f015-4e78-af55-c945d1434579.png">



<!-- XXXX é o numero da tarefa/issue - isto é para quando fizermos merge desta alteração fechar a issue original automaticamente -->
Fixes #XXXX


### Como testar esta modificação?

<!-- Descreve os testes que executaste para verificar tuas alterações. Diz-nos as instruções ou GIFs para que possamos reproduzir. Lista todos os detalhes relevantes para o teu teste. -->


### Checklist:

<!-- **Apaga as opções irrelevantes.** -->

- [ ] O meu PR segue as regras de estilo de código deste projeto
- [ ] Eu fiz uma autoavaliação (review) do meu próprio código ou materiais
- [ ] Eu fiz as alterações correspondentes na documentação
