### PR TITLE
Fix layout na página Privacy Policy

### DIFF
--- a/src/pages/PrivacyPolicy/index.js
+++ b/src/pages/PrivacyPolicy/index.js
@@ -16,10 +16,10 @@ function PrivacyPolicy({ translation }) {
   ];
 
   function WebOrMobileClassName() {
-    var className = "";
+    var className = '';
 
     if (window.innerWidth <= 500) {
-      className = "container-mobile";
+      className = 'container-mobile';
     }
 
     return className;

--- a/src/pages/PrivacyPolicy/index.js
+++ b/src/pages/PrivacyPolicy/index.js
@@ -15,12 +15,22 @@ function PrivacyPolicy({ translation }) {
     }
   ];
 
+  function WebOrMobileClassName() {
+    var className = "";
+
+    if (window.innerWidth <= 500) {
+      className = "container-mobile";
+    }
+
+    return className;
+  }
+
   return (
     <PageLayout
       title={translation('PrivacyPolicyPage-PageName')}
       descriptionParagraphs={[translation('PrivacyPolicyPage-Description')]}
       breadcrumbsData={breadcrumbs}>
-      <Container fluid="md">
+      <Container fluid="md" className={WebOrMobileClassName()}>
         <Row>
           <p>{translation('PrivacyPolicyPage-Text_p1')}</p>
           <p>{translation('PrivacyPolicyPage-Text_p2')}</p>

--- a/src/pages/PrivacyPolicy/index.js
+++ b/src/pages/PrivacyPolicy/index.js
@@ -15,22 +15,12 @@ function PrivacyPolicy({ translation }) {
     }
   ];
 
-  function WebOrMobileClassName() {
-    var className = '';
-
-    if (window.innerWidth <= 500) {
-      className = 'container-mobile';
-    }
-
-    return className;
-  }
-
   return (
     <PageLayout
       title={translation('PrivacyPolicyPage-PageName')}
       descriptionParagraphs={[translation('PrivacyPolicyPage-Description')]}
       breadcrumbsData={breadcrumbs}>
-      <Container fluid="md" className={WebOrMobileClassName()}>
+      <Container fluid="md" className="container-mobile">
         <Row>
           <p>{translation('PrivacyPolicyPage-Text_p1')}</p>
           <p>{translation('PrivacyPolicyPage-Text_p2')}</p>

--- a/src/pages/PrivacyPolicy/privacy-policy.scss
+++ b/src/pages/PrivacyPolicy/privacy-policy.scss
@@ -5,6 +5,8 @@ h5 {
   margin-top: 30px !important;
 }
 
-.container-mobile {
-  margin-top: 15px;
+@media (max-width: 768px) {
+  .container-mobile {
+    margin-top: 15px;
+  }
 }

--- a/src/pages/PrivacyPolicy/privacy-policy.scss
+++ b/src/pages/PrivacyPolicy/privacy-policy.scss
@@ -4,3 +4,7 @@ h3,
 h5 {
   margin-top: 30px !important;
 }
+
+.container-mobile {
+  margin-top: 15px;
+}


### PR DESCRIPTION
### Descrição
Correção do layout da página da Política de Privacidade para ecrã mobile. Foi adicionado um espaçamento superior ao texto da página mobile para que este não fique parcialmente escondido. 

Fixes #163

### Como testar esta modificação?
Abrir a versão mobile do site no browser. Ir à página relativa à Política de Privacidade e verificar que o texto inicial já não se encontra semi-escondido. 

### Checklist:
- [ ] O meu PR segue as regras de estilo de código deste projeto
- [ ] Eu fiz uma autoavaliação (review) do meu próprio código ou materiais