### PR TITLE
Adicionar Jest ao pre-commit hook

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,4 +1,5 @@
 module.exports = {
   '*.{js,jsx,ts,tsx,css}': 'eslint --config .eslintrc.js --fix',
+  '*.{js,jsx,ts,tsx,css}': 'jest --bail --findRelatedTests --passWithNoTests',
   '*': 'prettier --ignore-unknown --write --config .prettierrc'
 };


### PR DESCRIPTION
### Descrição

<!-- Inclui um resumo das alterações e motivação / contexto relevante. Lista todas as dependências necessárias para essa mudança. -->
Tal como tinha sido falado no PR #192, adicionei o script de testes ao pre-commit hook para garantir que alterações aos componentes não causam regressões de funcionalidades.

### Como testar esta modificação?

<!-- Descreve os testes que executaste para verificar tuas alterações. Diz-nos as instruções ou GIFs para que possamos reproduzir. Lista todos os detalhes relevantes para o teu teste. -->

Tendo em conta que neste momento o único componente com testes é a página NotFound404, é possível testar este PR fazendo uma alteração a src/pages/NotFound404/index.js e tentando fazer commit sem antes atualizar a snapshot. O pre-commit hook vai correr e falhar nesse teste.

Outra forma de testar é fazer commit de qualquer outro ficheiro alterado e conferir no terminal que o comando `jest --findRelatedTests --passWithNoTests` foi uma das etapas do processo.

### Checklist:

<!-- **Apaga as opções irrelevantes.** -->

- [x] O meu PR segue as regras de estilo de código deste projeto
- [x] Eu fiz uma autoavaliação (review) do meu próprio código ou materiais
